### PR TITLE
Add the ability to recognise the ACTION CTCP command

### DIFF
--- a/src/Phergie/Irc/Parser.php
+++ b/src/Phergie/Irc/Parser.php
@@ -206,7 +206,7 @@ class Parser implements ParserInterface
         $params = "(?P<params>$trailing?|(?:$middle{0,14}$trailing)|(?:$middle{0,15}))";
         $name = "[$letter](?:[$letter$number\\-]*[$letter$number])?";
         $host = "$name(?:\\.$name)+";
-        $nick = "(?:[$letter][$letter$number\\-\\[\\]\\\\`^{}]*)";
+        $nick = "(?:[$letter][$letter$number\\-\\[\\]\\\\`^{}\\_]*)";
         $user = "(?:[^ $null$crlf]+)";
         $prefix = "(?:(?P<servername>$host)|(?P<nick>$nick)(?:!(?P<user>$user))?(?:@$host)?)";
         $message = "(?P<prefix>:$prefix )?$command$params$crlf";

--- a/tests/Phergie/Irc/ParserTest.php
+++ b/tests/Phergie/Irc/ParserTest.php
@@ -151,6 +151,18 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'targets' => array('Wiz'),
                 ),
             ),
+            
+            array(
+                "NICK :Wiz_\r\n",
+                array(
+                    'command' => 'NICK',
+                    'params' => array(
+                        'nickname' => 'Wiz_',
+                        'all' => 'Wiz_',
+                    ),
+                    'targets' => array('Wiz_'),
+                ),
+            ),
 
             array(
                 "NICK Wiz :1\r\n",
@@ -2161,6 +2173,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
             
+            // ACTION (CTCP Specification)
             array(
                 ":john!~jsmith@example.com PRIVMSG #test :\001ACTION test\001\r\n",
                 array(


### PR DESCRIPTION
Hi there,

This is a simple one-line fix to add support for the ACTION CTCP command.

Tested this using the following code:

``` php
<?php
require 'src/Phergie/Irc/ParserInterface.php';
require 'src/Phergie/Irc/Parser.php';

$parser = new \Phergie\Irc\Parser();
print_r($parser->parse(":henri!~hwatson@henriwatson.com PRIVMSG #test :".chr(01)."ACTION test".chr(01)."\r\n"));
```

Which should output the following:

```
Array
(
    [prefix] => :henri!~hwatson@henriwatson.com
    [nick] => henri
    [user] => ~hwatson@henriwatson.com
    [command] => PRIVMSG
    [params] => Array
        (
            [all] => #test :ACTION test
            [receivers] => #test
            [text] => ACTION test
        )

    [message] => :henri!~hwatson@henriwatson.com PRIVMSG #test :ACTION test

    [targets] => Array
        (
            [0] => #test
        )

    [ctcp] => Array
        (
            [command] => ACTION
            [params] => Array
                (
                    [all] => test
                )

        )

)
```

Thanks!
