### PR TITLE
Set code to command if it isn't RFC standard

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -385,7 +385,7 @@ class Parser implements ParserInterface
             if (isset($this->replies[$command])) {
                 $parsed['code'] = $this->replies[$command];
             } else {
-                $parsed['code'] = 'Unknown reply';
+                $parsed['code'] = $command;
             }
             if (!empty($parsed['params'])) {
                 $all = $this->strip($parsed['params']);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -2171,7 +2171,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 "999\r\n",
                 array(
                     'command' => '999',
-                    'code' => 'Unknown reply',
+                    'code' => '999',
                 ),
             ),
             
@@ -2523,7 +2523,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                         6 => 'bkloveqjfI',
                         'all' => 'Phergie3 pratchett.freenode.net ircd-seven-1.1.3 DOQRSZaghilopswz CFILMPQbcefgijklmnopqrstvz bkloveqjfI',
                     ),
-                    'code' => 'Unknown reply',
+                    'code' => '004',
                 ),
             ),
 
@@ -2541,7 +2541,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                         'all' => 'Phergie3 #laravel :http://laravel.com',
                     ),
                     'message' => ":services. 328 Phergie3 #laravel :http://laravel.com\r\n",
-                    'code' => 'Unknown reply',
+                    'code' => '328',
                 ),
             ),
 


### PR DESCRIPTION
There are a bunch of [IRC codes](https://www.alien.net.au/irc/irc2numerics.html) that aren't RFC standard. This way they get emitted as they are, f.e. instead of emiting nothing for the server code 671, it emits 'irc.received.671'. 