### PR TITLE
Change MODE parameter processing

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -231,7 +231,7 @@ class Parser implements ParserInterface
             'SQUIT'    => "/^(?:(?P<server>$middle)(?P<comment>$trailing))$/",
             'JOIN'     => "/^(?:(?P<channels>$middle|$trailing)(?P<keys>$trailing)?)$/",
             'PART'     => "/^(?:(?P<channels>$middle|$trailing)(?P<message>$trailing)?)$/",
-            'MODE'     => "/^(?:(?P<target>$middle)(?P<mode>$middle|$trailing)(?P<param>$trailing)?)$/",
+            'MODE'     => "/^(?:(?P<target>$middle)(?P<mode>$middle|$trailing)(?P<params>$trailing)?)$/",
             'TOPIC'    => "/^(?:(?P<channel>$middle|$trailing)(?P<topic>$trailing)?)$/",
             'NAMES'    => "/^(?:(?P<channels>$trailing))$/",
             'LIST'     => "/^(?:(?:(?P<channels>$trailing)|$middle)?(?P<server>$trailing)?)$/",
@@ -349,20 +349,31 @@ class Parser implements ParserInterface
                 case 'MODE':
                     if (preg_match('/^' . $this->channel . '$/', $params['target'])) {
                         $params['channel'] = $params['target'];
-                        if (strpos($params['mode'], 'l') !== false) {
-                            $params['limit'] = $params['param'];
-                        } elseif (strpos($params['mode'], 'b') !== false
-                            && !empty($params['param'])) {
-                            $params['banmask'] = $params['param'];
-                        } elseif (strpos($params['mode'], 'k') !== false) {
-                            $params['key'] = $params['param'];
-                        } elseif (isset($params['param'])) {
-                            $params['user'] = $params['param'];
+
+                        /* Assign the value of $params['params'] to a named parameter if
+                         * only one channel mode is being set.
+                         * This functionality is DEPRECATED, and will not occur if more than one
+                         * channel mode is being set. Use $params['params'] instead. */
+                        if (strlen($params['mode']) == 2 && isset($params['params'])) {
+                            switch ($params['mode']{1}) {
+                                case 'l':
+                                    $params['limit'] = $params['params'];
+                                    break;
+                                case 'b':
+                                    $params['banmask'] = $params['params'];
+                                    break;
+                                case 'k':
+                                    $params['key'] = $params['params'];
+                                    break;
+                                default:
+                                    $params['user'] = $params['params'];
+                                    break;
+                            }
                         }
                     } else {
                         $params['user'] = $params['target'];
                     }
-                    unset($params['target'], $params['param']);
+                    unset($params['target']);
                     break;
                 // Handle CTCP messages
                 case 'PRIVMSG':

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -456,6 +456,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'params' => array(
                         'channel' => '#Finnish',
                         'mode' => '+o',
+                        'params' => 'Kilroy',
                         'user' => 'Kilroy',
                         'all' => '#Finnish +o :Kilroy',
                     ),
@@ -470,8 +471,37 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'params' => array(
                         'channel' => '#Finnish',
                         'mode' => '+v',
+                        'params' => 'Wiz',
                         'user' => 'Wiz',
                         'all' => '#Finnish +v :Wiz',
+                    ),
+                    'targets' => array('#Finnish'),
+                ),
+            ),
+
+            array(
+                "MODE #Finnish +ov :Kilroy Wiz\r\n",
+                array(
+                    'command' => 'MODE',
+                    'params' => array(
+                        'channel' => '#Finnish',
+                        'mode' => '+ov',
+                        'params' => 'Kilroy Wiz',
+                        'all' => '#Finnish +ov :Kilroy Wiz',
+                    ),
+                    'targets' => array('#Finnish'),
+                ),
+            ),
+
+            array(
+                "MODE #Finnish +mvv-v :Kilroy Wiz Angel\r\n",
+                array(
+                    'command' => 'MODE',
+                    'params' => array(
+                        'channel' => '#Finnish',
+                        'mode' => '+mvv-v',
+                        'params' => 'Kilroy Wiz Angel',
+                        'all' => '#Finnish +mvv-v :Kilroy Wiz Angel',
                     ),
                     'targets' => array('#Finnish'),
                 ),
@@ -497,8 +527,23 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'params' => array(
                         'channel' => '#42',
                         'mode' => '+k',
+                        'params' => 'oulu',
                         'key' => 'oulu',
                         'all' => '#42 +k :oulu',
+                    ),
+                    'targets' => array('#42'),
+                ),
+            ),
+
+            array(
+                "MODE #42 +ks :oulu\r\n",
+                array(
+                    'command' => 'MODE',
+                    'params' => array(
+                        'channel' => '#42',
+                        'mode' => '+ks',
+                        'params' => 'oulu',
+                        'all' => '#42 +ks :oulu',
                     ),
                     'targets' => array('#42'),
                 ),
@@ -511,8 +556,23 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'params' => array(
                         'channel' => '#eu-opers',
                         'mode' => '+l',
+                        'params' => '10',
                         'limit' => '10',
                         'all' => '#eu-opers +l :10',
+                    ),
+                    'targets' => array('#eu-opers'),
+                ),
+            ),
+
+            array(
+                "MODE #eu-opers +lL :10 #eu-opers-overflow\r\n",
+                array(
+                    'command' => 'MODE',
+                    'params' => array(
+                        'channel' => '#eu-opers',
+                        'mode' => '+lL',
+                        'params' => '10 #eu-opers-overflow',
+                        'all' => '#eu-opers +lL :10 #eu-opers-overflow',
                     ),
                     'targets' => array('#eu-opers'),
                 ),
@@ -538,6 +598,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'params' => array(
                         'channel' => '&oulu',
                         'mode' => '+b',
+                        'params' => '*!*@*',
                         'banmask' => '*!*@*',
                         'all' => '&oulu +b :*!*@*',
                     ),
@@ -552,8 +613,23 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'params' => array(
                         'channel' => '&oulu',
                         'mode' => '+b',
+                        'params' => '*!*@*.edu',
                         'banmask' => '*!*@*.edu',
                         'all' => '&oulu +b :*!*@*.edu',
+                    ),
+                    'targets' => array('&oulu'),
+                ),
+            ),
+
+            array(
+                "MODE &oulu +b-b :*!*@*.edu *!*@*.ac.uk\r\n",
+                array(
+                    'command' => 'MODE',
+                    'params' => array(
+                        'channel' => '&oulu',
+                        'mode' => '+b-b',
+                        'params' => '*!*@*.edu *!*@*.ac.uk',
+                        'all' => '&oulu +b-b :*!*@*.edu *!*@*.ac.uk',
                     ),
                     'targets' => array('&oulu'),
                 ),
@@ -597,6 +673,34 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                         'all' => 'Wiz :-o',
                     ),
                     'targets' => array('Wiz'),
+                ),
+            ),
+
+            array(
+                "MODE Kilroy +s :+CcQq\r\n",
+                array(
+                    'command' => 'MODE',
+                    'params' => array(
+                        'user' => 'Kilroy',
+                        'mode' => '+s',
+                        'params' => '+CcQq',
+                        'all' => 'Kilroy +s :+CcQq',
+                    ),
+                    'targets' => array('Kilroy'),
+                ),
+            ),
+
+            array(
+                "MODE Angel +ws :+CcQq\r\n",
+                array(
+                    'command' => 'MODE',
+                    'params' => array(
+                        'user' => 'Angel',
+                        'mode' => '+ws',
+                        'params' => '+CcQq',
+                        'all' => 'Angel +ws :+CcQq',
+                    ),
+                    'targets' => array('Angel'),
                 ),
             ),
 


### PR DESCRIPTION
ref: #17

In order to improve handling of multiple mode changes, trailing parameters
are now stored in `$params['params']`, rather than in an individual named
parameter depending on the mode change (`$params['key']` etc.)

Event handlers that process MODE messages should now use `$params['params']`,
and process it as appropriate, rather than using a named parameter.

If there is only one channel mode change, then the named parameter will
still be populated as before, for backwards compatibility. Relying on this
behaviour should be considered DEPRECATED.

Added appropriate test cases.