### PR TITLE
Minor parser regex changes

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -206,10 +206,10 @@ class Parser implements ParserInterface
         // ? provides for relaxed parsing of messages without trailing parameters properly demarcated
         $trailing = "(?: :?[^$null$crlf]*)";
         $params = "(?P<params>$trailing?|(?:$middle{0,14}$trailing))";
-        $name = "[$letter](?:[$letter$number\\-]*[$letter$number])?";
+        $name = "[$letter$number](?:[$letter$number\\-]*[$letter$number])?";
         $host = "$name(?:\\.(?:$name)*)+";
         $nick = "(?:[$letter$special][$letter$number$special-]*)";
-        $user = "(?:[^ $null$crlf]+)";
+        $user = "(?:[^ $null$crlf@]+)";
         $prefix = "(?:(?P<servername>$host)|(?:(?P<nick>$nick)(?:!(?P<user>$user))?(?:@(?P<host>$host))?))";
         $message = "(?P<prefix>:$prefix )?$command$params$crlf";
         $this->message = "/^$message/SU";

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -2767,6 +2767,45 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'targets' => array('hello|there'),
                 ),
             ),
+
+            // Hostnames/idents
+            array(
+                ":nick!ident@123.host.com PRIVMSG target :message\r\n",
+                array(
+                    'prefix' => ':nick!ident@123.host.com',
+                    'nick' => 'nick',
+                    'user' => 'ident',
+                    'host' => '123.host.com',
+                    'command' => 'PRIVMSG',
+                    'params' => array(
+                        'all' => 'target :message',
+                        'receivers' => 'target',
+                        'text' => 'message',
+                    ),
+                    'targets' => array('target'),
+                ),
+            ),
+
+            array(
+                ":nick!ident- PRIVMSG target :message\r\n",
+                array(
+                    'prefix' => ':nick!ident-',
+                    'nick' => 'nick',
+                    'user' => 'ident-',
+                    'command' => 'PRIVMSG',
+                    'params' => array(
+                        'all' => 'target :message',
+                        'receivers' => 'target',
+                        'text' => 'message',
+                    ),
+                    'targets' => array('target'),
+                ),
+            ),
+
+            array(
+                ":nick!ident@- PRIVMSG target :message\r\n",
+                null,
+            ),
         );
 
         foreach ($data as $key => $value) {


### PR DESCRIPTION
hostname elements can take a digit as first character (RFC1123)
idents cannot contain @ characters (RFC2812)