### PR TITLE
Fix consume() truncating incomplete lines from buffer

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -469,7 +469,10 @@ class Parser implements ParserInterface
      */
     public function consume(&$message)
     {
-        $parsed = $this->parse($message);
+        if (($parsed = $this->parse($message)) === null) {
+            return null;
+        }
+
         $message = empty($parsed['tail']) ? '' : $parsed['tail'];
         return $parsed;
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -59,8 +59,11 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     public function testConsume($message, $result)
     {
         $parser = new Parser;
+        $temp = $message;
         $this->assertEquals($result, $parser->consume($message));
-        if (isset($result['tail'])) {
+        if ($result === null) {
+            $this->assertEquals($message, $temp);
+        } elseif (isset($result['tail'])) {
             $this->assertEquals($message, $result['tail']);
         }
     }


### PR DESCRIPTION
Prevent `consume()` from attempting to overwrite the string buffer with the empty string when `parse()` returns `NULL`.