### PR TITLE
Numeric parsing: ensure params array is correctly indexed with no missing keys

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -417,8 +417,10 @@ class Parser implements ParserInterface
                     }
                     $params = explode(' ', $head);
                     $params[] = $tail;
-                    $parsed['params'] = array_filter($params);
-                    $parsed['params']['all'] = $all;
+                    if ($params = array_filter($params)) {
+                        $parsed['params'] = array_combine(range(1, count($params)), $params);
+                        $parsed['params']['all'] = $all;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Due to the way `explode()` is used in params parsing for numeric, the `$parsed['params']` array is currently 1-indexed rather than 0-indexed.

In addition, if an empty param is filtered out, it leaves a "hole" in the index sequence.

ie. `:server.name 001 Phergie3 :Welcome to the network` becomes:
``` php
array(
  1 => 'Welcome to the network',
)
```
and `:server.name 005 Phergie3 CHANMODES=b,k,l,nt  TOPICLEN=30 :are supported by this server` becomes:
``` php
array(
  1 => 'CHANMODES=b,k,l,nt',
  3 => 'TOPICLEN=30',
  4 => 'are supported by this server',
)
```

This changeset re-indexes the params array to ensure the array keys are always sequential integers beginning at 0. With it, the second example above becomes:
``` php
array(
  0 => 'CHANMODES=b,k,l,nt',
  1 => 'TOPICLEN=30',
  2 => 'are supported by this server',
)
```

Comments needed, as this is a **breaking change** for any plugin that uses a parameter at a specific index when parsing a numeric. This was also the case with #14, and at the time, the plugins known to be affected were UserMode and OpsWorksDeployment.