### PR TITLE
Also allow underscores in the hostname of an IRC message.

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -206,7 +206,7 @@ class Parser implements ParserInterface
         // ? provides for relaxed parsing of messages without trailing parameters properly demarcated
         $trailing = "(?: :?[^$null$crlf]*)";
         $params = "(?P<params>$trailing?|(?:$middle{0,14}$trailing))";
-        $name = "[$letter$number](?:[$letter$number:\\/\\-]*[$letter$number])?";
+        $name = "[$letter$number](?:[$letter$number:\\/\\-\\_]*[$letter$number])?";
         $host = "$name(?:\\.(?:$name)*)*";
         $nick = "(?:[$letter$special][$letter$number$special-]*)";
         $user = "(?:[^ $null$crlf@]+)";

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -206,7 +206,7 @@ class Parser implements ParserInterface
         // ? provides for relaxed parsing of messages without trailing parameters properly demarcated
         $trailing = "(?: :?[^$null$crlf]*)";
         $params = "(?P<params>$trailing?|(?:$middle{0,14}$trailing))";
-        $name = "[$letter$number](?:[$letter$number:\\/\\-\\_]*[$letter$number])?";
+        $name = "[$letter$number](?:[$letter$number:\\/\\-_]*[$letter$number])?";
         $host = "$name(?:\\.(?:$name)*)*";
         $nick = "(?:[$letter$special][$letter$number$special-]*)";
         $user = "(?:[^ $null$crlf@]+)";

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1217,6 +1217,40 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
 
+            array(
+                ":foobar1!foobar2@foobar3.user.network PRIVMSG #channel :hi all\r\n",
+                array(
+                    'prefix' => ':foobar1!foobar2@foobar3.user.network',
+                    'nick' => 'foobar1',
+                    'user' => 'foobar2',
+                    'host' => 'foobar3.user.network',
+                    'command' => 'PRIVMSG',
+                    'params' => array(
+                        'receivers' => '#channel',
+                        'text' => 'hi all',
+                        'all' => '#channel :hi all',
+                    ),
+                    'targets' => array('#channel'),
+                ),
+            ),
+
+            array(
+                ":foo_bar1!foo_bar2@foo_bar3.user.network PRIVMSG #channel :hi all\r\n",
+                array(
+                    'prefix' => ':foo_bar1!foo_bar2@foo_bar3.user.network',
+                    'nick' => 'foo_bar1',
+                    'user' => 'foo_bar2',
+                    'host' => 'foo_bar3.user.network',
+                    'command' => 'PRIVMSG',
+                    'params' => array(
+                        'receivers' => '#channel',
+                        'text' => 'hi all',
+                        'all' => '#channel :hi all',
+                    ),
+                    'targets' => array('#channel'),
+                ),
+            ),
+
             // NOTE: Because of syntactic equivalence, data sets for NOTICE
             // (RFC 1459 Section 4.4.2) equivalent to those for PRIVMSG are
             // derived later in this method rather than being duplicated here


### PR DESCRIPTION
I noticed a bug in the parser, it does not allow underscores to be in the hostname. This can happen very regularly with fakehosts, which are very common on some networks.

This PR fixes that bug.