### PR TITLE
Fixes #34 and #39 parsing nicknames and user hosts

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -207,7 +207,7 @@ class Parser implements ParserInterface
         $trailing = "(?: :?[^$null$crlf]*)";
         $params = "(?P<params>$trailing?|(?:$middle{0,14}$trailing))";
         $host = '[^ ]+';
-        $nick = "(?:[$letter$special][$letter$number$special-]*)";
+        $nick = "(?:[\\*$letter$special][$letter$number$special-]*)";
         $user = "(?:[^ $null$crlf@]+)";
         $prefix = "(?:(?:(?P<nick>$nick)(?:!(?P<user>$user))?(?:@(?P<host>$host))?)|(?P<servername>$host))";
         $message = "(?P<prefix>:$prefix )?$command$params$crlf";

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -206,8 +206,7 @@ class Parser implements ParserInterface
         // ? provides for relaxed parsing of messages without trailing parameters properly demarcated
         $trailing = "(?: :?[^$null$crlf]*)";
         $params = "(?P<params>$trailing?|(?:$middle{0,14}$trailing))";
-        $name = "[$letter$number](?:[$letter$number:\\/\\-_]*[$letter$number])?";
-        $host = "$name(?:\\.(?:$name)*)*";
+        $host = '[^ ]+';
         $nick = "(?:[$letter$special][$letter$number$special-]*)";
         $user = "(?:[^ $null$crlf@]+)";
         $prefix = "(?:(?:(?P<nick>$nick)(?:!(?P<user>$user))?(?:@(?P<host>$host))?)|(?P<servername>$host))";

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -2973,6 +2973,42 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'targets' => array('#/b/'),
                 ),
             ),
+
+            // Asterisk (*) in nickname. Used mainly by modules of IRC bouncers like ZNC.
+            array(
+                ":*status!znc@znc.in PRIVMSG thebot :Error from Server [Closing Link: 127.0.0.1 (Killed (linear (youtube loop)))]\r\n",
+                array(
+                    'prefix' => ":*status!znc@znc.in",
+                    'nick' => '*status',
+                    'user' => 'znc',
+                    'host' => "znc.in",
+                    'command' => 'PRIVMSG',
+                    'params' => array(
+                        'receivers' => 'thebot',
+                        'text' => 'Error from Server [Closing Link: 127.0.0.1 (Killed (linear (youtube loop)))]',
+                        'all' => 'thebot :Error from Server [Closing Link: 127.0.0.1 (Killed (linear (youtube loop)))]',
+                    ),
+                    'targets' => array('thebot'),
+                ),
+            ),
+
+            // On Quakenet it seems that server can set usermode.
+            array(
+                ":*.quakenet.org MODE #example +o mike1256\r\n",
+                array(
+                    'prefix' => ":*.quakenet.org",
+                    'servername' => '*.quakenet.org',
+                    'command' => 'MODE',
+                    'params' => array(
+                        'all' => '#example +o mike1256',
+                        'mode' => '+o',
+                        'channel' => '#example',
+                        'user' => 'mike1256',
+                        'params' => 'mike1256',
+                    ),
+                    'targets' => array('#example'),
+                ),
+            ),
         );
 
         foreach ($data as $key => $value) {

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -2925,13 +2925,6 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             ),
 
             array(
-                ":nick!ident@- PRIVMSG target :message\r\n",
-                array(
-                    'invalid' => ":nick!ident@- PRIVMSG target :message\r\n",
-                ),
-            ),
-
-            array(
                 ":nick!ident@localhost PRIVMSG target :message\r\n",
                 array(
                     'prefix' => ':nick!ident@localhost',
@@ -2961,6 +2954,23 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                         'realname' => 'Ronnie Reagan',
                     ),
                     'targets' => array('myident'),
+                ),
+            ),
+
+            // Color codes in hostname. Possible for example on Rizon.
+            array(
+                ":Float_!~pi@\x034Float\x030.\x0310Rizon\x030.\x034Rules\x03 JOIN :#/b/\r\n",
+                array(
+                    'prefix' => ":Float_!~pi@\x034Float\x030.\x0310Rizon\x030.\x034Rules\x03",
+                    'nick' => 'Float_',
+                    'user' => '~pi',
+                    'host' => "\x034Float\x030.\x0310Rizon\x030.\x034Rules\x03",
+                    'command' => 'JOIN',
+                    'params' => array(
+                        'all' => ':#/b/',
+                        'channels' => '#/b/',
+                    ),
+                    'targets' => array('#/b/'),
                 ),
             ),
         );


### PR DESCRIPTION
1. On some networks it's possible to have color codes in vhosts. I think it's pointless to add more and more exceptions to RFC, when we can simply accept all characters except spaces.
Ex. `:Float_!~pi@4Float0.10Rizon0.4Rules JOIN :#/b/\r\n`

2. On Quakenet such message can appear:
`:*.quakenet.org MODE #example +o mike1256\r\n`
It's also not valid according to standards, because it has asterisk inside hostname.

3. Bouncers like ZNC use virtual nicknames starting with asterisk for internal communication. Parser seems to doesn't recognize them:
`:*status!znc@znc.in PRIVMSG thebot :Error from Server [Closing Link: 127.0.0.1 (Killed (linear (youtube loop)))]\r\n`

This pull request fixes all those issues and removes one test, which is unlikely to happen in real environment.