### PR TITLE
Allowing ~ character in nicks. It is allowed in some networks.

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -207,7 +207,7 @@ class Parser implements ParserInterface
         $trailing = "(?: :?[^$null$crlf]*)";
         $params = "(?P<params>$trailing?|(?:$middle{0,14}$trailing))";
         $host = '[^ ]+';
-        $nick = "(?:[\\*$letter$special][$letter$number$special-]*)";
+        $nick = "(?:[\\*$letter$special][$letter$number$special-~]*)";
         $user = "(?:[^ $null$crlf@]+)";
         $prefix = "(?:(?:(?P<nick>$nick)(?:!(?P<user>$user))?(?:@(?P<host>$host))?)|(?P<servername>$host))";
         $message = "(?P<prefix>:$prefix )?$command$params$crlf";

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -199,7 +199,7 @@ class Parser implements ParserInterface
         $crlf = "\r\n";
         $letter = 'a-zA-Z';
         $number = '0-9';
-        $special = preg_quote('[]\`_^{|}');
+        $special = preg_quote('[]\`_^{|}~');
         $null = '\\x00';
         $command = "(?P<command>[$letter]+|[$number]{3})";
         $middle = "(?: [^ $null$crlf:][^ $null$crlf]*)";
@@ -207,7 +207,7 @@ class Parser implements ParserInterface
         $trailing = "(?: :?[^$null$crlf]*)";
         $params = "(?P<params>$trailing?|(?:$middle{0,14}$trailing))";
         $host = '[^ ]+';
-        $nick = "(?:[\\*$letter$special][$letter$number$special-~]*)";
+        $nick = "(?:[\\*$letter$special][$letter$number$special-]*)";
         $user = "(?:[^ $null$crlf@]+)";
         $prefix = "(?:(?:(?P<nick>$nick)(?:!(?P<user>$user))?(?:@(?P<host>$host))?)|(?P<servername>$host))";
         $message = "(?P<prefix>:$prefix )?$command$params$crlf";

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -525,6 +525,22 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
 
+            // Testing nicks with ~
+            array(
+                "MODE #Finnish +o :Kilroy~\r\n",
+                array(
+                    'command' => 'MODE',
+                    'params' => array(
+                        'channel' => '#Finnish',
+                        'mode' => '+o',
+                        'params' => 'Kilroy~',
+                        'user' => 'Kilroy~',
+                        'all' => '#Finnish +o :Kilroy~',
+                    ),
+                    'targets' => array('#Finnish'),
+                ),
+            ),
+
             array(
                 "MODE #Finnish +v :Wiz\r\n",
                 array(

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1165,6 +1165,22 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
 
+            // Test nicks with ~
+            array(
+                ":Angel~ PRIVMSG Wiz~ :Hello are you receiving this message ?\r\n",
+                array(
+                    'prefix' => ':Angel~',
+                    'nick' => 'Angel~',
+                    'command' => 'PRIVMSG',
+                    'params' => array(
+                        'receivers' => 'Wiz~',
+                        'text' => 'Hello are you receiving this message ?',
+                        'all' => 'Wiz~ :Hello are you receiving this message ?',
+                    ),
+                    'targets' => array('Wiz~'),
+                ),
+            ),
+
             array(
                 "PRIVMSG Angel :yes I'm receiving it !receiving it !'u>(768u+1n) .br\r\n",
                 array(


### PR DESCRIPTION
In some networks, like ChatHispano (http://www.chathispano.com/), ~ character is allowed in nicks (not at the begginning) so it is not parsing well the messages with this nicks.